### PR TITLE
Fix overlapping

### DIFF
--- a/src/components/TutorialEditor/GalleryListView.tsx
+++ b/src/components/TutorialEditor/GalleryListView.tsx
@@ -48,7 +48,7 @@ const GalleryListView = (props: GalleryViewProps) => {
                 <div className="lg:w-[calc(100%-400px)] md:w-[calc(100%-276px)] break-all text-left">
                   {item.title}
                 </div>
-                <div className="lg:w-44 md:w-24 grid text-left max-md:grid-cols-2 gap-2">
+                <div className="lg:w-44 md:w-24 grid text-left break-all max-md:grid-cols-2 gap-2">
                   <span className="text-xs text-subtext md:hidden">File Name</span>
                   {fileName && <span className="max-md:text-xs">{fileName}</span>}
                 </div>


### PR DESCRIPTION
Fix overlapping in `fileName` field on Media page

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208858212995589