### PR TITLE
Unable to Edit Pages on Teacher Dashboard

### DIFF
--- a/src/components/TutorialEditor/FileElement.tsx
+++ b/src/components/TutorialEditor/FileElement.tsx
@@ -84,8 +84,8 @@ const FileElement = (props: QuizElementProps) => {
           subchapterIndex: props.subchapterIndex,
           file: {
             file: fileData,
-            description: { text: fileDescription, isValid: fileDescription.trim().length > 0 },
-            title: { text: fileTitle, isValid: fileTitle.trim().length > 0 },
+            description: { text: fileDescription, isValid: fileDescription?.trim()?.length > 0 },
+            title: { text: fileTitle, isValid: fileTitle?.trim()?.length > 0 },
           },
         }),
       )


### PR DESCRIPTION
- Fix errors in `FileElement` component related to empty `title` and `description` fields