### PR TITLE
Feat/subchapter titles

### DIFF
--- a/src/components/TutorialEditor/AddMediaElement.tsx
+++ b/src/components/TutorialEditor/AddMediaElement.tsx
@@ -302,6 +302,7 @@ const AddMediaElement = (props: AddMediaElementProps) => {
           layout: props.layout,
           listIndex: props.listIndex,
           media: {
+            subchapterTitle: mediaDataState.subchapterTitle,
             id: mediaDataState.id ?? undefined,
             format: mediaDataState.format,
             link: mediaDataState.url ?? mediaDataState.link,
@@ -324,6 +325,7 @@ const AddMediaElement = (props: AddMediaElementProps) => {
             layout: props.layout,
             nestedIndex: props.chapterIndex,
             image: {
+              subchapterTitle: mediaDataState.subchapterTitle,
               id: mediaDataState.id ?? undefined,
               format: mediaDataState.format,
               link: mediaDataState.url ?? mediaDataState.link,

--- a/src/components/TutorialEditor/AddSectionBlock.tsx
+++ b/src/components/TutorialEditor/AddSectionBlock.tsx
@@ -20,9 +20,12 @@ interface AddSectionBlockProps {
     index?: number,
     subchapterIndex?: number,
     showTitle?: boolean,
+    isSubchapter?: boolean,
   ) => void
   chapterIndex?: number
   subchapterIndex?: number
+  isSubchapter?: boolean
+  setIsSubchapterCreating: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const AddSectionBlock = (props: AddSectionBlockProps) => {
@@ -42,11 +45,19 @@ const AddSectionBlock = (props: AddSectionBlockProps) => {
 
   const createSection = (layoutType: LayoutChapterType) => {
     setIsSectionCreating(false)
+
+    if (props.isSubchapter) {
+      props.setIsSubchapterCreating(true)
+    } else {
+      props.setIsSubchapterCreating(false)
+    }
+
     props.handleAddElement(
       layoutType,
       props.chapterIndex,
       props.subchapterIndex,
       layoutType === '1 column' || isSubchapter,
+      props.isSubchapter,
     )
   }
 

--- a/src/components/TutorialEditor/ChapterContent.tsx
+++ b/src/components/TutorialEditor/ChapterContent.tsx
@@ -16,6 +16,7 @@ interface ChapterContentProps {
   handleChapterTextInputChange: (val: string, index: number) => void
   handleAddElement: (val: string, index?: number) => void
   elements: AddElementsType[]
+  setIsSubchapterCreating: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const ChapterContent = (props: ChapterContentProps) => {
@@ -132,6 +133,7 @@ const ChapterContent = (props: ChapterContentProps) => {
         variant="outline"
         chapterIndex={chapterIndex}
         handleAddElement={handleAddElement}
+        setIsSubchapterCreating={props.setIsSubchapterCreating}
       />
     </>
   )

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -62,8 +62,13 @@ const ChapterSection = (props: ChapterSectionProps) => {
     }
     if (val === 'infobox block') {
       payload.infobox = {
-        text: '',
-        isValid: true,
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
+        text: { text: '', isValid: true },
       }
       delete payload['infobox block']
     }

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -134,6 +134,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
       }
     } else if (val === 'download file') {
       payload.file = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         file: { id: undefined, url: '', isValid: true },
         title: { text: '', isValid: true },
         description: { text: '', isValid: true },

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -85,8 +85,15 @@ const ChapterSection = (props: ChapterSectionProps) => {
       }
     } else if (val === 'h5p element') {
       payload.h5pElement = {
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         text: '',
         error: '',
+        isValid: true,
       }
       delete payload['h5p element']
     } else if (val === 'tutorial cards') {

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -97,21 +97,37 @@ const ChapterSection = (props: ChapterSectionProps) => {
           title: item.title,
           isValid: true,
         }))
-        payload.tutorialCards = [
-          {
-            value: { id: undefined, title: '', isValid: true },
-            proposedList: tutorials,
-          },
-        ]
+        payload.tutorialCards = {
+          title: isSubchapterCreating
+            ? {
+                text: '',
+                isValid: true,
+              }
+            : undefined,
+          items: [
+            {
+              value: { id: undefined, title: '', isValid: true },
+              proposedList: tutorials,
+            },
+          ],
+        }
         delete payload['tutorial cards']
       } catch (error: any) {
         if (error.response && error.response.status === 404) {
-          payload.tutorialCards = [
-            {
-              value: { id: undefined, title: '', isValid: true },
-              proposedList: [],
-            },
-          ]
+          payload.tutorialCards = {
+            title: isSubchapterCreating
+              ? {
+                  text: '',
+                  isValid: true,
+                }
+              : undefined,
+            items: [
+              {
+                value: { id: undefined, title: '', isValid: true },
+                proposedList: [],
+              },
+            ],
+          }
         } else {
           console.error(error)
         }

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -191,6 +191,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
       }
     } else if (val === 'external video') {
       payload.externalVideo = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         title: { text: '', isValid: true },
         url: { text: '', isValid: true },
         thumbnail: undefined,

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -125,6 +125,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
       delete payload['download file']
     } else if (val === 'image') {
       payload.image = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         format: '',
         link: '',
         url: '',

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import EditorLabel from '../ui/EditorLabel'
 import { AddElementsType, ChapterInterface } from 'src/types/types'
 import { useAppDispatch } from 'src/redux/hooks'
@@ -23,6 +23,7 @@ interface ChapterSectionProps {
 
 const ChapterSection = (props: ChapterSectionProps) => {
   const { chapter, index } = props
+  const [isSubchapterCreating, setIsSubchapterCreating] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
 
@@ -45,10 +46,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
 
     if (val === 'text block') {
       payload.textLayout = {
-        title: {
-          text: '',
-          isValid: true,
-        },
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         text: {
           text: '',
           isValid: true,
@@ -261,9 +264,16 @@ const ChapterSection = (props: ChapterSectionProps) => {
         handleAddElement={handleAddElement}
         handleChangeChapterTitle={handleChangeChapterTitle}
         handleChapterTextInputChange={handleChapterTextInputChange}
+        setIsSubchapterCreating={setIsSubchapterCreating}
         chapterIndex={index}
       />
-      <AddSectionBlock variant="dashed" chapterIndex={index} handleAddElement={handleAddElement} />
+      <AddSectionBlock
+        variant="dashed"
+        chapterIndex={index}
+        handleAddElement={handleAddElement}
+        setIsSubchapterCreating={setIsSubchapterCreating}
+        isSubchapter={true}
+      />
     </section>
   )
 }

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -74,6 +74,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
     }
     if (val === 'quiz') {
       payload[val] = {
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         question: { text: '', isValid: true },
         answers: [
           { answer: '', isCorrect: '1', isValid: true },

--- a/src/components/TutorialEditor/ChapterSection.tsx
+++ b/src/components/TutorialEditor/ChapterSection.tsx
@@ -144,6 +144,12 @@ const ChapterSection = (props: ChapterSectionProps) => {
       }
     } else if (val === 'video') {
       payload.video = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         format: '',
         link: '',
         url: '',

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -7,6 +7,7 @@ import {
   setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
+  setTutorialCardsTitle,
   setVideoTitle,
 } from 'src/redux/features/editorSlice'
 import { AddElementsType, ChapterElementsObject } from 'src/types/types'
@@ -94,6 +95,24 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setVideoTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleTutorialCardsElementTitleChange = (
+    value: string,
+    index?: number,
+    block?: string,
+  ): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setTutorialCardsTitle({
           block,
           index,
           value,
@@ -489,11 +508,24 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.tutorialCards?.title !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.tutorialCards.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.tutorialCards.title.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) =>
+                      handleTutorialCardsElementTitleChange(e.target.value, index, block)
+                    }
+                  />
+                </div>
+              )}
               <TutorialCardsElement
                 block={block}
                 chapterIndex={chapterIndex}
                 index={index}
-                tutorialCards={element.tutorialCards}
+                tutorialCards={element.tutorialCards.items}
               />
             </DeleteElementWraper>
           )}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -5,6 +5,7 @@ import {
   changeSubchapterTitle,
   setElementText,
   setFileSubchapterTitle,
+  setH5PElementTitle,
   setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
@@ -128,6 +129,20 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setFileSubchapterTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleH5PElementTitleChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setH5PElementTitle({
           block,
           index,
           value,
@@ -682,6 +697,17 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.h5pElement?.title !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.h5pElement.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.h5pElement.title.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleH5PElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <H5pElement
                 block={props.block}
                 chapterIndex={props.chapterIndex}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -4,6 +4,7 @@ import {
   changeSubchapterText,
   changeSubchapterTitle,
   setElementText,
+  setExternalVideoElementTitle,
   setFileSubchapterTitle,
   setH5PElementTitle,
   setImageTitle,
@@ -143,6 +144,24 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setH5PElementTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleExternalVideoElementTitleChange = (
+    value: string,
+    index?: number,
+    block?: string,
+  ): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setExternalVideoElementTitle({
           block,
           index,
           value,
@@ -639,6 +658,19 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               elementIndex={index}
               styles="bg-white top-3 right-1 w-6 h-6"
             >
+              {element.externalVideo?.subchapterTitle !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.externalVideo?.subchapterTitle.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.externalVideo?.subchapterTitle.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) =>
+                      handleExternalVideoElementTitleChange(e.target.value, index, block)
+                    }
+                  />
+                </div>
+              )}
               <ExternalVideoElement
                 block={block}
                 chapterIndex={props.chapterIndex}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -4,6 +4,7 @@ import {
   changeSubchapterText,
   changeSubchapterTitle,
   setElementText,
+  setFileSubchapterTitle,
   setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
@@ -113,6 +114,20 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setTutorialCardsTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleFileElementTitleChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setFileSubchapterTitle({
           block,
           index,
           value,
@@ -626,6 +641,17 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               styles="bg-white top-3 right-1 w-6 h-6"
               file={element.file.file?.id}
             >
+              {element.file?.subchapterTitle !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.file?.subchapterTitle.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.file?.subchapterTitle.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleFileElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <FileElement
                 block={props.block}
                 chapterIndex={props.chapterIndex}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -109,22 +109,24 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
-              <div className="relative w-full mt-4 mb-5 ">
-                <input
-                  type="text"
-                  className={`${element.textLayout.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
-                  value={element.textLayout.title.text}
-                  placeholder={'Subchapter Title'}
-                  onChange={(e) =>
-                    handleSubchapterTitleChange(
-                      e.target.value,
-                      index,
-                      'textLayout',
-                      props.chapterIndex,
-                    )
-                  }
-                />
-              </div>
+              {element.textLayout?.title && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.textLayout.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.textLayout.title.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) =>
+                      handleSubchapterTitleChange(
+                        e.target.value,
+                        index,
+                        'textLayout',
+                        props.chapterIndex,
+                      )
+                    }
+                  />
+                </div>
+              )}
               <div className="w-full flex flex-col sm:flex-row justify-between gap-6">
                 <div className="w-full">
                   <BundledEditor

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -3,8 +3,9 @@ import { useAppDispatch } from 'src/redux/hooks'
 import {
   changeSubchapterText,
   changeSubchapterTitle,
-  setElementInfobox,
   setElementText,
+  setInfoboxText,
+  setInfoboxTitle,
 } from 'src/redux/features/editorSlice'
 import { AddElementsType, ChapterElementsObject } from 'src/types/types'
 import AddMediaElement from './AddMediaElement'
@@ -30,6 +31,7 @@ interface ElementsBlockProps {
 const ElementsBlock = (props: ElementsBlockProps) => {
   const { elements, block, chapterIndex, subchapterIndex } = props
   const dispatch = useAppDispatch()
+
   const handleTextElementChange = (value: string, index?: number, block?: string): void => {
     if (block !== undefined && index !== undefined) {
       dispatch(
@@ -44,13 +46,27 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     }
   }
 
-  const handleInfoboxElementChange = (value: string, index?: number, block?: string): void => {
+  const handleInfoboxElementTitleChange = (value: string, index?: number, block?: string): void => {
     if (block !== undefined && index !== undefined) {
       dispatch(
-        setElementInfobox({
+        setInfoboxTitle({
           block,
           index,
-          infobox: { text: value, isValid: true },
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleInfoboxElementTextChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setInfoboxText({
+          block,
+          index,
+          value,
           nestedIndex: chapterIndex,
           subchapterIndex,
         }),
@@ -416,12 +432,23 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.infobox?.title !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.infobox.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.infobox.title.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleInfoboxElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <BundledEditor
-                value={element.infobox.text}
+                value={element.infobox.text.text}
                 block={block}
                 index={index}
-                handleChange={handleInfoboxElementChange}
-                notValid={!element.infobox.isValid}
+                handleChange={handleInfoboxElementTextChange}
+                notValid={!element.infobox.text.isValid}
               />
             </DeleteElementWraper>
           )}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -4,6 +4,7 @@ import {
   changeSubchapterText,
   changeSubchapterTitle,
   setElementText,
+  setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
 } from 'src/redux/features/editorSlice'
@@ -64,6 +65,20 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setInfoboxText({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleImageElementTitleChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setImageTitle({
           block,
           index,
           value,
@@ -474,6 +489,17 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.image?.subchapterTitle !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.image?.subchapterTitle.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.image?.subchapterTitle.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleImageElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <AddMediaElement
                 mediaType="image"
                 block={props.block}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -10,6 +10,7 @@ import {
   setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
+  setQuizElementTitle,
   setTutorialCardsTitle,
   setVideoTitle,
 } from 'src/redux/features/editorSlice'
@@ -162,6 +163,20 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setExternalVideoElementTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleQuizElementTitleChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setQuizElementTitle({
           block,
           index,
           value,
@@ -714,6 +729,17 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.quiz?.title !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.quiz.title.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.quiz.title.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleQuizElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <QuizElement
                 block={props.block}
                 chapterIndex={props.chapterIndex}

--- a/src/components/TutorialEditor/ElementsBlock.tsx
+++ b/src/components/TutorialEditor/ElementsBlock.tsx
@@ -7,6 +7,7 @@ import {
   setImageTitle,
   setInfoboxText,
   setInfoboxTitle,
+  setVideoTitle,
 } from 'src/redux/features/editorSlice'
 import { AddElementsType, ChapterElementsObject } from 'src/types/types'
 import AddMediaElement from './AddMediaElement'
@@ -79,6 +80,20 @@ const ElementsBlock = (props: ElementsBlockProps) => {
     if (block !== undefined && index !== undefined) {
       dispatch(
         setImageTitle({
+          block,
+          index,
+          value,
+          nestedIndex: chapterIndex,
+          subchapterIndex,
+        }),
+      )
+    }
+  }
+
+  const handleVideoElementTitleChange = (value: string, index?: number, block?: string): void => {
+    if (block !== undefined && index !== undefined) {
+      dispatch(
+        setVideoTitle({
           block,
           index,
           value,
@@ -517,6 +532,17 @@ const ElementsBlock = (props: ElementsBlockProps) => {
               subchapterIndex={subchapterIndex}
               elementIndex={index}
             >
+              {element.video?.subchapterTitle !== undefined && (
+                <div className="relative w-full mt-4 mb-5 ">
+                  <input
+                    type="text"
+                    className={`${element.video?.subchapterTitle.isValid ? '' : 'border border-red-500 rounded-md'} w-full rounded-[4px] border border-inputBorder bg-background-seasalt px-2 py-[10px] text-xl leading-8 placeholder:text-tertiary-grey-stone`}
+                    value={element.video?.subchapterTitle.text}
+                    placeholder={'Subchapter Title'}
+                    onChange={(e) => handleVideoElementTitleChange(e.target.value, index, block)}
+                  />
+                </div>
+              )}
               <div className="w-full flex flex-col gap-y-4">
                 <AddMediaElement
                   mediaType="video"

--- a/src/components/TutorialEditor/TutorialBottomSection.tsx
+++ b/src/components/TutorialEditor/TutorialBottomSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import EditorLabel from '../ui/EditorLabel'
 import BundledEditor from './BundledEditor'
 import Tip from '../ui/Tip'
@@ -22,6 +22,8 @@ interface TutorialBottomSectionProps {
 const TutorialBottomSection = (props: TutorialBottomSectionProps) => {
   const dispatch = useAppDispatch()
 
+  const [isSubchapterCreating, setIsSubchapterCreating] = useState<boolean>(false)
+
   const tutorialBottom = useAppSelector((state: RootState) => state.editor.tutorialBottom)
   const handleTutorialBottomTextChange = (val: string) => {
     dispatch(setTutorialBottomText(val))
@@ -42,9 +44,17 @@ const TutorialBottomSection = (props: TutorialBottomSectionProps) => {
     const payload: any = {}
     payload[val] = ''
     if (val === 'text block') {
-      payload.text = {
-        text: '',
-        isValid: true,
+      payload.textLayout = {
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
+        text: {
+          text: '',
+          isValid: true,
+        },
       }
       delete payload['text block']
       dispatch(addTutorialBottomElements(payload))
@@ -262,10 +272,19 @@ const TutorialBottomSection = (props: TutorialBottomSectionProps) => {
       />
 
       {!tutorialBottomStateElements.find((el) => el.defaultVal) && (
-        <AddSectionBlock variant="outline" handleAddElement={handleAddTutorialBottomElement} />
+        <AddSectionBlock
+          variant="outline"
+          handleAddElement={handleAddTutorialBottomElement}
+          setIsSubchapterCreating={setIsSubchapterCreating}
+        />
       )}
 
-      <AddSectionBlock variant="dashed" handleAddElement={handleAddTutorialBottomElement} />
+      <AddSectionBlock
+        variant="dashed"
+        handleAddElement={handleAddTutorialBottomElement}
+        setIsSubchapterCreating={setIsSubchapterCreating}
+        isSubchapter
+      />
     </section>
   )
 }

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -93,6 +93,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'h5p element') {
       payload.h5pElement = {
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         text: '',
         error: '',
         isValid: true,

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -81,6 +81,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'quiz') {
       payload[val] = {
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         question: { text: '', isValid: true },
         answers: [
           { answer: '', isCorrect: '1', isValid: true },

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -107,20 +107,36 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
           title: item.title,
           isValid: true,
         }))
-        payload.tutorialCards = [
-          {
-            value: { id: undefined, title: '', isValid: true },
-            proposedList: tutorials,
-          },
-        ]
-      } catch (error: any) {
-        if (error.response && error.response.status === 404) {
-          payload.tutorialCards = [
+        payload.tutorialCards = {
+          title: isSubchapterCreating
+            ? {
+                text: '',
+                isValid: true,
+              }
+            : undefined,
+          items: [
             {
               value: { id: undefined, title: '', isValid: true },
-              proposedList: [],
+              proposedList: tutorials,
             },
-          ]
+          ],
+        }
+      } catch (error: any) {
+        if (error.response && error.response.status === 404) {
+          payload.tutorialCards = {
+            title: isSubchapterCreating
+              ? {
+                  text: '',
+                  isValid: true,
+                }
+              : undefined,
+            items: [
+              {
+                value: { id: undefined, title: '', isValid: true },
+                proposedList: [],
+              },
+            ],
+          }
         } else {
           console.error(error)
         }

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -137,6 +137,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'image') {
       payload.image = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         format: '',
         link: '',
         url: '',

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -145,6 +145,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'download file') {
       payload.file = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         file: { id: undefined, url: '', isValid: true },
         title: { text: '', isValid: true },
         description: { text: '', isValid: true },

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -50,7 +50,6 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
     subchapterIndex?: number,
     showTitle?: boolean,
   ): Promise<void> => {
-    console.log(`value: ${val} | isSubchapter: ${isSubchapterCreating}`)
     const payload: any = {}
     payload[val] = ''
     if (val === 'text block') {
@@ -70,8 +69,13 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'infobox block') {
       payload.infobox = {
-        text: '',
-        isValid: true,
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
+        text: { text: '', isValid: true },
       }
       delete payload['infobox block']
       dispatch(addTutorialElements(payload))

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import EditorLabel from 'src/components/ui/EditorLabel'
 import TextInput from 'src/components/ui/TextInput'
 import Tip from 'src/components/ui/Tip'
@@ -24,6 +24,8 @@ interface TutorialTopSectionProps {
 const TutorialTopSection = (props: TutorialTopSectionProps) => {
   const { tutorialTitle } = props
 
+  const [isSubchapterCreating, setIsSubchapterCreating] = useState<boolean>(false)
+
   const tutorialDescription = useAppSelector(
     (state: RootState) => state.editor.tutorialTop.description,
   )
@@ -48,14 +50,17 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
     subchapterIndex?: number,
     showTitle?: boolean,
   ): Promise<void> => {
+    console.log(`value: ${val} | isSubchapter: ${isSubchapterCreating}`)
     const payload: any = {}
     payload[val] = ''
     if (val === 'text block') {
       payload.textLayout = {
-        title: {
-          text: '',
-          isValid: true,
-        },
+        title: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         text: {
           text: '',
           isValid: true,
@@ -286,10 +291,19 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       />
 
       {!tutorialStateElements.find((el) => el.defaultVal) && (
-        <AddSectionBlock variant="outline" handleAddElement={handleAddTutorialElement} />
+        <AddSectionBlock
+          variant="outline"
+          handleAddElement={handleAddTutorialElement}
+          setIsSubchapterCreating={setIsSubchapterCreating}
+        />
       )}
 
-      <AddSectionBlock variant="dashed" handleAddElement={handleAddTutorialElement} />
+      <AddSectionBlock
+        variant="dashed"
+        handleAddElement={handleAddTutorialElement}
+        setIsSubchapterCreating={setIsSubchapterCreating}
+        isSubchapter={true}
+      />
     </section>
   )
 }

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -157,6 +157,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'video') {
       payload.video = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         format: '',
         link: '',
         url: '',

--- a/src/components/TutorialEditor/TutorialTopSection.tsx
+++ b/src/components/TutorialEditor/TutorialTopSection.tsx
@@ -204,6 +204,12 @@ const TutorialTopSection = (props: TutorialTopSectionProps) => {
       dispatch(addTutorialElements(payload))
     } else if (val === 'external video') {
       payload.externalVideo = {
+        subchapterTitle: isSubchapterCreating
+          ? {
+              text: '',
+              isValid: true,
+            }
+          : undefined,
         title: { text: '', isValid: true },
         url: { text: '', isValid: true },
         thumbnail: undefined,

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -205,8 +205,11 @@ export const reducerParser = {
             case 'tu-delft-info-box':
               return {
                 infobox: {
-                  text: block.block_data.content,
-                  isValid: true,
+                  title:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
+                  text: { text: block.block_data.content, isValid: true },
                 },
               }
             case 'tu-delft-quiz':
@@ -1036,7 +1039,8 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-info-box',
                 block_data: {
-                  content: item.infobox.text,
+                  title: item.infobox.title !== undefined ? item.infobox.title.text : undefined,
+                  content: item.infobox.text.text,
                 },
               }
             }

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -438,7 +438,13 @@ export const reducerParser = {
               }
 
               return {
-                tutorialCards,
+                tutorialCards: {
+                  title:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
+                  items: tutorialCards,
+                },
               }
             case 'tu-delft-video-url':
               return {
@@ -1070,7 +1076,7 @@ export const reducerParser = {
               }
             }
             if (item.tutorialCards) {
-              const transformedData: TransformedDataTutorialCards = item.tutorialCards.reduce(
+              const transformedData: TransformedDataTutorialCards = item.tutorialCards.items.reduce(
                 (acc: TransformedDataTutorialCards, card, index) => {
                   const isCustomLink = card.value.url !== undefined ? '_custom' : ''
                   acc[`content_card_row_${index}_card_title`] = card.value.title
@@ -1084,11 +1090,17 @@ export const reducerParser = {
                     card.value.url !== undefined
                   return acc
                 },
-                { content_card_row: item.tutorialCards.length },
+                { content_card_row: item.tutorialCards.items.length },
               )
               return {
                 block_name: 'tu-delft-content-card',
-                block_data: transformedData,
+                block_data: {
+                  title:
+                    item.tutorialCards.title !== undefined
+                      ? item.tutorialCards.title.text
+                      : undefined,
+                  ...transformedData,
+                },
               }
             }
             if (item.h5pElement) {

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -280,6 +280,10 @@ export const reducerParser = {
                       ]
                     : 'unknown',
                   title: block.block_data.content ? block.block_data.content : '',
+                  subchapterTitle:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
                   publishDate: 'hardcode',
                   thumbnail: {
                     id: block.block_data.thumbnail,
@@ -1113,6 +1117,10 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-video',
                 block_data: {
+                  title:
+                    item.video.subchapterTitle !== undefined
+                      ? item.video.subchapterTitle.text
+                      : undefined,
                   video: item.video.id,
                   video_url: item.video.url,
                   thumbnail: item.video.thumbnail?.id ?? null,

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -260,6 +260,10 @@ export const reducerParser = {
                       ]
                     : 'unknown',
                   title: block.block_data.content ? block.block_data.content : '',
+                  subchapterTitle:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
                   publishDate: 'hardcode',
                   hasZoom: block.block_data.has_image_zoom ?? false,
                 },
@@ -1095,6 +1099,10 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-image',
                 block_data: {
+                  title:
+                    item.image.subchapterTitle !== undefined
+                      ? item.image.subchapterTitle.text
+                      : undefined,
                   image: item.image.id,
                   image_url: item.image.url,
                   has_image_zoom: item.image.hasZoom ?? false,

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -215,6 +215,10 @@ export const reducerParser = {
             case 'tu-delft-quiz':
               return {
                 quiz: {
+                  title:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
                   question: { text: block.block_data.question, isValid: true },
                   answers: [
                     {
@@ -1074,6 +1078,7 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-quiz',
                 block_data: {
+                  title: item.quiz.title !== undefined ? item.quiz.title.text : undefined,
                   question: item.quiz.question.text,
                   answers_0_answer: item.quiz.answers[0].answer,
                   answers_0_is_correct: item.quiz.answers[0].isCorrect,

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -453,6 +453,10 @@ export const reducerParser = {
             case 'tu-delft-video-url':
               return {
                 externalVideo: {
+                  subchapter_title:
+                    block.block_data.subchapter_title !== undefined
+                      ? { text: block.block_data.subchapter_title, isValid: true }
+                      : undefined,
                   title: { text: block.block_data.title ?? '', isValid: !!block.block_data.title },
                   url: { text: block.block_data.url ?? '', isValid: !!block.block_data.url },
                   thumbnail: {
@@ -1154,6 +1158,10 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-video-url',
                 block_data: {
+                  subchapter_title:
+                    item.externalVideo.subchapterTitle !== undefined
+                      ? item.externalVideo.subchapterTitle.text
+                      : undefined,
                   title: item.externalVideo.title.text,
                   url: item.externalVideo.url.text,
                   thumbnail: item.externalVideo.thumbnail

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -1125,7 +1125,7 @@ export const reducerParser = {
                 block_name: 'tu-delft-text',
                 block_data: {
                   content: item.textLayout.text.text,
-                  title: item.textLayout.title.text ?? undefined,
+                  title: item.textLayout?.title?.text ?? undefined,
                 },
               }
             }

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -244,6 +244,10 @@ export const reducerParser = {
             case 'tu-delft-h5p':
               return {
                 h5pElement: {
+                  title:
+                    block.block_data.title !== undefined
+                      ? { text: block.block_data.title, isValid: true }
+                      : undefined,
                   text: block.block_data.source,
                   isValid: true,
                 },
@@ -1111,6 +1115,8 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-h5p',
                 block_data: {
+                  title:
+                    item.h5pElement.title !== undefined ? item.h5pElement.title.text : undefined,
                   source: item.h5pElement.text,
                 },
               }

--- a/src/lib/reducerParser.ts
+++ b/src/lib/reducerParser.ts
@@ -512,6 +512,10 @@ export const reducerParser = {
             case 'tu-delft-download':
               return {
                 file: {
+                  subchapterTitle:
+                    block.block_data.subchapter_title !== undefined
+                      ? { text: block.block_data.subchapter_title, isValid: true }
+                      : undefined,
                   title: block.block_data.title ? block.block_data.title : '',
                   file: {
                     id: block.block_data.file,
@@ -1219,6 +1223,10 @@ export const reducerParser = {
               return {
                 block_name: 'tu-delft-download',
                 block_data: {
+                  subchapter_title:
+                    item.file.subchapterTitle !== undefined
+                      ? item.file.subchapterTitle.text
+                      : undefined,
                   file: item.file.file?.id,
                   file_url: item.file.file?.url,
                   title: item.file.title,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -209,13 +209,18 @@ const validateElements = (
         }),
       }
     } else if (element.textLayout) {
-      const isTitleValid = element.textLayout.title.text.trim().length > 0
+      const isTitleValid = element.textLayout?.title
+        ? element.textLayout.title.text.trim().length > 0
+        : true
       !isTitleValid && count++
       const isTextValid = element.textLayout.text.text.trim().length > 0
       !isTextValid && count++
+
       return {
         textLayout: {
-          title: { ...element.textLayout.title, isValid: isTitleValid },
+          title: element.textLayout?.title
+            ? { ...element.textLayout.title, isValid: isTitleValid }
+            : undefined,
           text: { ...element.textLayout.text, isValid: isTextValid },
         },
       }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -212,11 +212,14 @@ const validateElements = (
         },
       }
     } else if (element.quiz) {
+      const isTitleValid = element.quiz?.title ? element.quiz.title.text.trim().length > 0 : true
+      !isTitleValid && count++
       const isQuestionValid = element.quiz.question.text.trim().length > 0
       !isQuestionValid && count++
       return {
         quiz: {
           ...element.quiz,
+          title: element.quiz?.title ? { ...element.quiz.title, isValid: isTitleValid } : undefined,
           question: { ...element.quiz.question, isValid: isQuestionValid },
           answers: element.quiz.answers.map((answer) => {
             const isValidAnswer = answer.answer.trim().length > 0

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -117,10 +117,19 @@ const validateElements = (
       !isValid && count++
       return { text: { ...element.text, isValid } }
     } else if (element.infobox) {
-      const isValid = element.infobox.text.trim().length > 0
+      const isTitleValid = element.infobox?.title
+        ? element.infobox.title.text.trim().length > 0
+        : true
+      !isTitleValid && count++
+      const isValid = element.infobox.text.text.trim().length > 0
       !isValid && count++
       return {
-        infobox: { ...element.infobox, isValid },
+        infobox: {
+          title: element.infobox?.title
+            ? { ...element.infobox.title, isValid: isTitleValid }
+            : undefined,
+          text: { ...element.infobox.text, isValid },
+        },
       }
     } else if (element.h5pElement) {
       const isValid = element.h5pElement.text.trim().length > 0

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -214,22 +214,36 @@ const validateElements = (
         },
       }
     } else if (element.tutorialCards) {
+      const isTitleValid =
+        element.tutorialCards.title !== undefined
+          ? element.tutorialCards.title.text.trim().length > 0
+          : true
+      !isTitleValid && count++
       return {
-        tutorialCards: element.tutorialCards.map((card) => {
-          const isCardValid =
-            card.value.id !== undefined ||
-            (card.value.url !== undefined &&
-              card.value.url.trim().length > 0 &&
-              card.value.title.trim().length > 0)
-          !isCardValid && count++
-          return {
-            ...card,
-            value: {
-              ...card.value,
-              isValid: isCardValid,
-            },
-          }
-        }),
+        tutorialCards: {
+          title:
+            element.tutorialCards.title !== undefined
+              ? {
+                  ...element.tutorialCards.title,
+                  isValid: isTitleValid,
+                }
+              : undefined,
+          items: element.tutorialCards.items.map((card) => {
+            const isCardValid =
+              card.value.id !== undefined ||
+              (card.value.url !== undefined &&
+                card.value.url.trim().length > 0 &&
+                card.value.title.trim().length > 0)
+            !isCardValid && count++
+            return {
+              ...card,
+              value: {
+                ...card.value,
+                isValid: isCardValid,
+              },
+            }
+          }),
+        },
       }
     } else if (element.textLayout) {
       const isTitleValid = element.textLayout?.title

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -141,11 +141,18 @@ const validateElements = (
         },
       }
     } else if (element.image) {
+      const isTitleValid = element.image?.subchapterTitle
+        ? element.image.subchapterTitle.text.trim().length > 0
+        : true
+      !isTitleValid && count++
       const isValid = !!element.image.id
       !isValid && count++
       return {
         image: {
           ...element.image,
+          subchapterTitle: element.image?.subchapterTitle
+            ? { ...element.image.subchapterTitle, isValid: isTitleValid }
+            : undefined,
           isValid,
         },
       }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -157,11 +157,18 @@ const validateElements = (
         },
       }
     } else if (element.video) {
+      const isTitleValid = element.video?.subchapterTitle
+        ? element.video.subchapterTitle.text.trim().length > 0
+        : true
+      !isTitleValid && count++
       const isValid = !!element.video.id
       !isValid && count++
       return {
         video: {
           ...element.video,
+          subchapterTitle: element.video?.subchapterTitle
+            ? { ...element.video.subchapterTitle, isValid: isTitleValid }
+            : undefined,
           isValid,
         },
       }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -333,12 +333,20 @@ const validateElements = (
         },
       }
     } else if (element.externalVideo) {
+      const isSubchapterTitleValid =
+        element.externalVideo.subchapterTitle !== undefined
+          ? element.externalVideo.subchapterTitle.text.trim().length > 0
+          : true
+      !isSubchapterTitleValid && count++
       const isTitleValid = element.externalVideo.title.text.trim().length > 0
       !isTitleValid && count++
       const isUrlValid = urlPattern.test(element.externalVideo.url.text)
       !isUrlValid && count++
       return {
         externalVideo: {
+          subchapterTitle: element.externalVideo?.subchapterTitle
+            ? { ...element.externalVideo.subchapterTitle, isValid: isTitleValid }
+            : undefined,
           title: { ...element.externalVideo.title, isValid: isTitleValid },
           url: { ...element.externalVideo.url, isValid: isUrlValid },
           thumbnail: element.externalVideo.thumbnail,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -179,9 +179,17 @@ const validateElements = (
       !isTitleValid && count++
       const isDescriptionValid = element.file.description.text.trim().length > 0
       !isDescriptionValid && count++
+      const isSubchapterTitleValid = element.file?.subchapterTitle
+        ? element.file.subchapterTitle.text.trim().length > 0
+        : true
+      !isSubchapterTitleValid && count++
+
       return {
         file: {
           ...element.file,
+          subchapterTitle: element.file?.subchapterTitle
+            ? { ...element.file.subchapterTitle, isValid: isSubchapterTitleValid }
+            : undefined,
           file: {
             ...element.file.file,
             isValid: isFileValid,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -132,11 +132,18 @@ const validateElements = (
         },
       }
     } else if (element.h5pElement) {
+      const isTitleValid = element.h5pElement?.title
+        ? element.h5pElement.title.text.trim().length > 0
+        : true
+      !isTitleValid && count++
       const isValid = element.h5pElement.text.trim().length > 0
       !isValid && count++
       return {
         h5pElement: {
           ...element.h5pElement,
+          title: element.h5pElement?.title
+            ? { ...element.h5pElement.title, isValid: isTitleValid }
+            : undefined,
           isValid,
         },
       }

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -626,6 +626,33 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setH5PElementTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].h5pElement &&
+            state.tutorialTop.elements[payload.index].h5pElement!.title !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].h5pElement!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].h5pElement!.title !==
+            undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].h5pElement!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1834,6 +1861,7 @@ export const {
   setVideoTitle,
   setTutorialCardsTitle,
   setFileSubchapterTitle,
+  setH5PElementTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -545,6 +545,33 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setVideoTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].video &&
+            state.tutorialTop.elements[payload.index].video!.subchapterTitle !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].video!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].video!.subchapterTitle !==
+            undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].video!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1747,6 +1774,7 @@ export const {
   setInfoboxTitle,
   setInfoboxText,
   setImageTitle,
+  setVideoTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -16,7 +16,7 @@ import {
   ElementFileActionInterface,
   ElementH5PActionInterface,
   ElementImageActionInterface,
-  ElementInfoboxActionInterface,
+  ElementInfoboxTitleActionInterface,
   ElementQuizActionInterface,
   ElementTextActionInterface,
   ElementVideoActionInterface,
@@ -450,18 +450,53 @@ export const editorSlice = createSlice({
         'text',
       )
     },
-    setElementInfobox: (state, action: PayloadAction<ElementInfoboxActionInterface>) => {
-      setElementProperty(
-        state,
-        {
-          ...action,
-          payload: {
-            ...action.payload,
-            value: action.payload.infobox,
-          },
-        },
-        'infobox',
-      )
+    setInfoboxTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].infobox &&
+            state.tutorialTop.elements[payload.index].infobox!.title !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].infobox!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].infobox!.title !== undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].infobox!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
+
+    setInfoboxText: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (state.tutorialTop.elements[payload.index].infobox !== undefined) {
+            state.tutorialTop.elements[payload.index].infobox!.text = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (state.chapters[payload.nestedIndex].elements[payload.index].infobox !== undefined) {
+            state.chapters[payload.nestedIndex].elements[payload.index].infobox!.text = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
     },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
@@ -1606,7 +1641,6 @@ export const {
   setPageType,
   addTutorialElements,
   setElementText,
-  setElementInfobox,
   addBlankChapter,
   setChapterText,
   setChapterTitle,
@@ -1663,6 +1697,8 @@ export const {
   setExternalVideoTitle,
   setExternalVideoUrl,
   addTutorialBottomElements,
+  setInfoboxTitle,
+  setInfoboxText,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -685,6 +685,32 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setQuizElementTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].quiz &&
+            state.tutorialTop.elements[payload.index].quiz!.title !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].quiz!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].quiz!.title !== undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].quiz!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1895,6 +1921,7 @@ export const {
   setFileSubchapterTitle,
   setH5PElementTitle,
   setExternalVideoElementTitle,
+  setQuizElementTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -653,6 +653,38 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setExternalVideoElementTitle: (
+      state,
+      action: PayloadAction<ElementInfoboxTitleActionInterface>,
+    ) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].externalVideo &&
+            state.tutorialTop.elements[payload.index].externalVideo!.subchapterTitle !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].externalVideo!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].externalVideo!
+              .subchapterTitle !== undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[
+              payload.index
+            ].externalVideo!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1862,6 +1894,7 @@ export const {
   setTutorialCardsTitle,
   setFileSubchapterTitle,
   setH5PElementTitle,
+  setExternalVideoElementTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -572,6 +572,33 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setTutorialCardsTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].tutorialCards &&
+            state.tutorialTop.elements[payload.index].tutorialCards!.title !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].tutorialCards!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].tutorialCards!.title !==
+            undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].tutorialCards!.title = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1217,32 +1244,32 @@ export const editorSlice = createSlice({
       if (block === 'tutorialElements') {
         const elements = state.tutorialTop.elements
         const element = elements && elements[listIndex]
-        if (element.tutorialCards !== undefined) {
+        if (element.tutorialCards !== undefined && element.tutorialCards.items !== undefined) {
           const newObject: TutorialCardInterface = {
             value: { id: undefined, title: '', isValid: true },
-            proposedList: element.tutorialCards[0].proposedList,
+            proposedList: element.tutorialCards.items[0].proposedList,
           }
-          element.tutorialCards = [...element.tutorialCards, newObject]
+          element.tutorialCards.items = [...element.tutorialCards.items, newObject]
         }
       } else if (block === 'tutorialBottomElements') {
         const elements = state.tutorialBottomContent
         const element = elements && elements[listIndex]
-        if (element.tutorialCards !== undefined) {
+        if (element.tutorialCards !== undefined && element.tutorialCards.items !== undefined) {
           const newObject: TutorialCardInterface = {
             value: { id: undefined, title: '', isValid: true },
-            proposedList: element.tutorialCards[0].proposedList,
+            proposedList: element.tutorialCards.items[0].proposedList,
           }
-          element.tutorialCards = [...element.tutorialCards, newObject]
+          element.tutorialCards.items = [...element.tutorialCards.items, newObject]
         }
       } else if (block === 'chapterElements' && chapterIndex !== undefined) {
         const elements = state.chapters[chapterIndex].elements
         const element = elements && elements[listIndex]
-        if (element.tutorialCards !== undefined) {
+        if (element.tutorialCards !== undefined && element.tutorialCards.items !== undefined) {
           const newObject: TutorialCardInterface = {
             value: { id: undefined, title: '', isValid: true },
-            proposedList: element.tutorialCards[0].proposedList,
+            proposedList: element.tutorialCards.items[0].proposedList,
           }
-          element.tutorialCards = [...element.tutorialCards, newObject]
+          element.tutorialCards.items = [...element.tutorialCards.items, newObject]
         }
       }
     },
@@ -1264,14 +1291,15 @@ export const editorSlice = createSlice({
         const element = elements && elements[listIndex]
         if (
           element.tutorialCards !== undefined &&
-          element.tutorialCards[nestedIndex].value !== undefined
+          element.tutorialCards.items !== undefined &&
+          element.tutorialCards.items[nestedIndex].value !== undefined
         ) {
           if (isUrl) {
-            element.tutorialCards[nestedIndex].value.id = undefined
-            element.tutorialCards[nestedIndex].value[`${name as 'title' | 'url'}`] = value
-            element.tutorialCards[nestedIndex].value.isValid = value.trim().length > 0
+            element.tutorialCards.items[nestedIndex].value.id = undefined
+            element.tutorialCards.items[nestedIndex].value[`${name as 'title' | 'url'}`] = value
+            element.tutorialCards.items[nestedIndex].value.isValid = value.trim().length > 0
           } else {
-            element.tutorialCards[nestedIndex].value = element.tutorialCards[
+            element.tutorialCards.items[nestedIndex].value = element.tutorialCards.items[
               nestedIndex
             ].proposedList.find((el) => el.id === parseInt(value)) ?? {
               id: undefined,
@@ -1285,14 +1313,15 @@ export const editorSlice = createSlice({
         const element = elements && elements[listIndex]
         if (
           element.tutorialCards !== undefined &&
-          element.tutorialCards[nestedIndex].value !== undefined
+          element.tutorialCards.items !== undefined &&
+          element.tutorialCards.items[nestedIndex].value !== undefined
         ) {
           if (isUrl) {
-            element.tutorialCards[nestedIndex].value.id = undefined
-            element.tutorialCards[nestedIndex].value[`${name as 'title' | 'url'}`] = value
-            element.tutorialCards[nestedIndex].value.isValid = value.trim().length > 0
+            element.tutorialCards.items[nestedIndex].value.id = undefined
+            element.tutorialCards.items[nestedIndex].value[`${name as 'title' | 'url'}`] = value
+            element.tutorialCards.items[nestedIndex].value.isValid = value.trim().length > 0
           } else {
-            element.tutorialCards[nestedIndex].value = element.tutorialCards[
+            element.tutorialCards.items[nestedIndex].value = element.tutorialCards.items[
               nestedIndex
             ].proposedList.find((el) => el.id === parseInt(value)) ?? {
               id: undefined,
@@ -1308,12 +1337,13 @@ export const editorSlice = createSlice({
 
         if (
           element.tutorialCards !== undefined &&
-          element.tutorialCards[nestedIndex].value !== undefined
+          element.tutorialCards.items !== undefined &&
+          element.tutorialCards.items[nestedIndex].value !== undefined
         ) {
           if (isUrl) {
-            element.tutorialCards[nestedIndex].value[`${name as 'title' | 'url'}`] = value
+            element.tutorialCards.items[nestedIndex].value[`${name as 'title' | 'url'}`] = value
           } else {
-            element.tutorialCards[nestedIndex].value = element.tutorialCards[
+            element.tutorialCards.items[nestedIndex].value = element.tutorialCards.items[
               nestedIndex
             ].proposedList.find((el) => el.id === parseInt(value)) ?? {
               id: undefined,
@@ -1775,6 +1805,7 @@ export const {
   setInfoboxText,
   setImageTitle,
   setVideoTitle,
+  setTutorialCardsTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -1080,7 +1080,7 @@ export const editorSlice = createSlice({
         }
         const element = elements[listIndex]
         const layoutItem = element[layout]
-        if (layoutItem && layoutItem.text !== undefined) {
+        if (layoutItem && layoutItem.text !== undefined && layoutItem.title !== undefined) {
           layoutItem.title.text = value
           layoutItem.title.isValid = true
         }
@@ -1090,7 +1090,7 @@ export const editorSlice = createSlice({
         const element = elements ? elements[listIndex] : undefined
         const layoutItem = element ? element[layout] : undefined
 
-        if (layoutItem && layoutItem.text !== undefined) {
+        if (layoutItem && layoutItem.text !== undefined && layoutItem.title !== undefined) {
           layoutItem.title.text = value
           layoutItem.title.isValid = true
         }

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -72,33 +72,54 @@ const setElementProperty = (state: any, action: PayloadAction<any>, property: ke
 
   if (block === 'tutorialElements' && index !== undefined) {
     if (layout) {
-      state.tutorialTop.elements[index][layout][property] = value
+      state.tutorialTop.elements[index][layout][property] = {
+        ...state.tutorialTop.elements[index][layout][property],
+        ...value,
+      }
     } else {
-      state.tutorialTop.elements[index][property] = value
+      state.tutorialTop.elements[index][property] = {
+        ...state.tutorialTop.elements[index][property],
+        ...value,
+      }
     }
   } else if (block === 'tutorialBottomElements' && index !== undefined) {
     if (layout) {
-      state.tutorialBottomContent[index][layout][property] = value
+      state.tutorialBottomContent[index][layout][property] = {
+        ...state.tutorialBottomContent[index][layout][property],
+        ...value,
+      }
     } else {
-      state.tutorialBottomContent[index][property] = value
+      state.tutorialBottomContent[index][property] = {
+        ...state.tutorialBottomContent[index][property],
+        ...value,
+      }
     }
   } else if (block === 'chapterElements' && index !== undefined && nestedIndex !== undefined) {
-    state.chapters[nestedIndex].elements[index][property] = value
+    state.chapters[nestedIndex].elements[index][property] = {
+      ...state.chapters[nestedIndex].elements[index][property],
+      ...value,
+    }
   } else if (
     block === 'subchapterElements' &&
     index !== undefined &&
     nestedIndex !== undefined &&
     subchapterIndex !== undefined
   ) {
-    state.chapters[nestedIndex].subchapters[subchapterIndex].elements[index][property] = value
+    state.chapters[nestedIndex].subchapters[subchapterIndex].elements[index][property] = {
+      ...state.chapters[nestedIndex].subchapters[subchapterIndex].elements[index][property],
+      ...value,
+    }
   } else if (block === 'chapterMedia' && nestedIndex !== undefined) {
-    state.chapters[nestedIndex][property] = value
+    state.chapters[nestedIndex][property] = { ...state.chapters[nestedIndex][property], ...value }
   } else if (
     block === 'subchapterMedia' &&
     nestedIndex !== undefined &&
     subchapterIndex !== undefined
   ) {
-    state.chapters[nestedIndex].subchapters[subchapterIndex][property] = value
+    state.chapters[nestedIndex].subchapters[subchapterIndex][property] = {
+      ...state.chapters[nestedIndex].subchapters[subchapterIndex][property],
+      ...value,
+    }
   }
 }
 
@@ -476,7 +497,6 @@ export const editorSlice = createSlice({
         }
       }
     },
-
     setInfoboxText: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
       const payload = action.payload
       if (payload.index !== undefined) {
@@ -491,6 +511,33 @@ export const editorSlice = createSlice({
         if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
           if (state.chapters[payload.nestedIndex].elements[payload.index].infobox !== undefined) {
             state.chapters[payload.nestedIndex].elements[payload.index].infobox!.text = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
+    setImageTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].image &&
+            state.tutorialTop.elements[payload.index].image!.subchapterTitle !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].image!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].image!.subchapterTitle !==
+            undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].image!.subchapterTitle = {
               text: payload.value,
               isValid: payload.value.trim().length > 0,
             }
@@ -1699,6 +1746,7 @@ export const {
   addTutorialBottomElements,
   setInfoboxTitle,
   setInfoboxText,
+  setImageTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/redux/features/editorSlice.ts
+++ b/src/redux/features/editorSlice.ts
@@ -599,6 +599,33 @@ export const editorSlice = createSlice({
         }
       }
     },
+    setFileSubchapterTitle: (state, action: PayloadAction<ElementInfoboxTitleActionInterface>) => {
+      const payload = action.payload
+      if (payload.index !== undefined) {
+        if (payload.block === 'tutorialElements') {
+          if (
+            state.tutorialTop.elements[payload.index].file &&
+            state.tutorialTop.elements[payload.index].file!.subchapterTitle !== undefined
+          ) {
+            state.tutorialTop.elements[payload.index].file!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+        if (payload.block === 'chapterElements' && payload.nestedIndex !== undefined) {
+          if (
+            state.chapters[payload.nestedIndex].elements[payload.index].file!.subchapterTitle !==
+            undefined
+          ) {
+            state.chapters[payload.nestedIndex].elements[payload.index].file!.subchapterTitle = {
+              text: payload.value,
+              isValid: payload.value.trim().length > 0,
+            }
+          }
+        }
+      }
+    },
     setElementImage: (state, action: PayloadAction<ElementImageActionInterface>) => {
       setElementProperty(
         state,
@@ -1806,6 +1833,7 @@ export const {
   setImageTitle,
   setVideoTitle,
   setTutorialCardsTitle,
+  setFileSubchapterTitle,
 } = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -167,6 +167,7 @@ export interface QuizAnswer {
   isValid: boolean
 }
 export interface QuizElement {
+  title?: TextElementInterface
   question: TextElementInterface
   answers: QuizAnswer[]
   answersCount: number

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -188,6 +188,7 @@ export interface h5pElementInterface {
   text: string
   error: string
   isValid: boolean
+  title?: TextElementInterface
 }
 export interface ElementH5PActionInterface extends ElementActionBase {
   h5pElement: h5pElementInterface

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -198,6 +198,7 @@ export interface CustomFileInterface {
   isValid: boolean
 }
 interface ElementsFileInterface {
+  subchapterTitle?: TextElementInterface
   file: CustomFileInterface
   title: TextElementInterface
   description: TextElementInterface

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -230,6 +230,11 @@ export interface TutorialCardInterface {
   proposedList: ProposedList[] | []
 }
 
+export interface TutorialCardsBlockInterface {
+  title?: TextElementInterface
+  items: TutorialCardInterface[]
+}
+
 interface MediaTextImageInterface {
   text: TextElementInterface
   image: MediaObjectInterface
@@ -258,7 +263,7 @@ export interface TutorialTopElementsObject {
   quiz?: QuizElement
   h5pElement?: h5pElementInterface
   tutorialCard?: TutorialCardInterface
-  tutorialCards?: TutorialCardInterface[]
+  tutorialCards?: TutorialCardsBlockInterface
   textLayout?: TextLayoutInterface
   textImage?: MediaTextImageInterface
   imageText?: MediaTextImageInterface
@@ -316,7 +321,7 @@ export interface ChapterElementsObject {
   video?: MediaObjectInterface
   externalVideo?: ExternalVideoInterface
   tutorialCard?: TutorialCardInterface
-  tutorialCards?: TutorialCardInterface[]
+  tutorialCards?: TutorialCardsBlockInterface
   file?: ElementsFileInterface
   quiz?: QuizElement
   h5pElement?: h5pElementInterface

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -113,12 +113,17 @@ export interface TextElementInterface {
   hidden?: boolean
 }
 
+interface TextLayoutInterface {
+  text: TextElementInterface
+  title?: TextElementInterface
+}
+
 export interface ElementTextActionInterface extends ElementActionBase {
   text: TextElementInterface
 }
 
-export interface ElementInfoboxActionInterface extends ElementActionBase {
-  infobox: TextElementInterface
+export interface ElementInfoboxTitleActionInterface extends ElementActionBase {
+  value: string
 }
 
 export interface ElementImageActionInterface extends ElementActionBase {
@@ -224,11 +229,6 @@ export interface TutorialCardInterface {
   proposedList: ProposedList[] | []
 }
 
-interface TextLayoutInterface {
-  text: TextElementInterface
-  title?: TextElementInterface
-}
-
 interface MediaTextImageInterface {
   text: TextElementInterface
   image: MediaObjectInterface
@@ -249,7 +249,7 @@ export interface ExternalVideoInterface {
 
 export interface TutorialTopElementsObject {
   text?: TextElementInterface
-  infobox?: TextElementInterface
+  infobox?: TextLayoutInterface
   image?: MediaObjectInterface
   video?: MediaObjectInterface
   externalVideo?: ExternalVideoInterface
@@ -310,7 +310,7 @@ export interface TermDialogInterface {
 
 export interface ChapterElementsObject {
   text?: TextElementInterface
-  infobox?: TextElementInterface
+  infobox?: TextLayoutInterface
   image?: MediaObjectInterface
   video?: MediaObjectInterface
   externalVideo?: ExternalVideoInterface

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -226,7 +226,7 @@ export interface TutorialCardInterface {
 
 interface TextLayoutInterface {
   text: TextElementInterface
-  title: TextElementInterface
+  title?: TextElementInterface
 }
 
 interface MediaTextImageInterface {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -91,7 +91,14 @@ interface MediaObjectParent {
 
 export interface ThumbnailInterface extends MediaObjectParent {}
 
+export interface TextElementInterface {
+  text: string
+  isValid: boolean
+  hidden?: boolean
+}
+
 export interface MediaObjectInterface {
+  subchapterTitle?: TextElementInterface
   id?: number
   link: string
   url?: string
@@ -105,12 +112,6 @@ export interface MediaObjectInterface {
   subtitles?: MediaObjectParent
   isOwner?: boolean
   hasZoom?: boolean
-}
-
-export interface TextElementInterface {
-  text: string
-  isValid: boolean
-  hidden?: boolean
 }
 
 interface TextLayoutInterface {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -250,6 +250,7 @@ interface MediaTextVideoInterface {
 }
 
 export interface ExternalVideoInterface {
+  subchapterTitle?: TextElementInterface
   title: TextElementInterface
   url: TextElementInterface
   thumbnail: ThumbnailInterface | undefined


### PR DESCRIPTION
- Separated subchapters from sections,
- Added field 'title' for subchapter that start from text-block,
- 
Added field 'title' for subchapter that start from infobox,
- 
Added 'title' for subchapter that starts with image,
- Added 'title' for subchapter that starts with video,
- Added 'title' for subchapter that starts with tutorial cards,
- Added 'title' for subchapter that starts with File-download,
- Added 'title' for subchapter that starts with h5pElement,
- 
Added 'title' for subchapter that starts with External video element,
- 
Added 'title' for subchapter that starts with Quiz element.